### PR TITLE
Fix invalid env name

### DIFF
--- a/bin/next-auth-all-access.js
+++ b/bin/next-auth-all-access.js
@@ -45,7 +45,7 @@ async function main(cmd, {jwksPath}) {
 Add the following line to your .env file, this is your private key:
 `);
   console.log(
-    `NEXTAUTHOIDC_PRIVATE_KEY='${privateKeyOneLine}'`,
+    `ALLACCESS_PRIVATE_KEY='${privateKeyOneLine}'`,
   );
 
   const publicJwk = await exportJWK(publicKey);


### PR DESCRIPTION
Thanks for this awesome package!

This PR just fixes the `.env` instruction to match the right env name.

## Context

https://github.com/takeshape/next-auth-all-access/blob/7cc5726094c60edba4defbdd2fd93fb5d85fb301/src/next-auth-all-access.ts#L45

`!==`

https://github.com/takeshape/next-auth-all-access/blob/7cc5726094c60edba4defbdd2fd93fb5d85fb301/bin/next-auth-all-access.js#L48